### PR TITLE
Pass along original http_host header

### DIFF
--- a/configs/nginx/readthedocs.conf
+++ b/configs/nginx/readthedocs.conf
@@ -39,7 +39,7 @@ server {
     location / {
         proxy_redirect off;
         proxy_pass_header Server;
-        proxy_set_header Host $host:$server_port;
+        proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Scheme $scheme;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Currently when we deploy RTD to production, AWS ELB listens on port 80 and forwards requests onwards to 8080 on which NGINX is listening on each host.

Since NGINX is configured to set host header to `$host:$server_port`, it passes host header incorrectly, since `server_port` which has the value `8080` isn't the port associated with the original request. 

It looks like Django then picks up this host header and attempts to use it in the redirect URI when doing Oauth with github. This redirect URI is not permitted which leads to an error and Oauth failing.

Wasn't able to test this out locally to see if it fixed github issue unfortunately.